### PR TITLE
updated readme with proper go get and import instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Golang SDK lets you easily build an ioElement with your favorite Go language. It
 
 Get sdk:
 ```go
-   go get github.com/iotracks/container-sdk-go
+   go get github.com/iofog/container-sdk-go
 ```
 
 Import sdk:
 ```go
    import (
-   sdk "github.com/iotracks/container-sdk-go"
+   sdk "github.com/iofog/container-sdk-go"
    )
 ```
 


### PR DESCRIPTION
The recent github org change from 'iotracks' to 'iofog' breaks the import path of the go sdk. 

this PR is a simple modification of the README to inform users to use the 'iofog' package instead of the 'iotracks' package.